### PR TITLE
Update gems

### DIFF
--- a/iglu-ruby-client.gemspec
+++ b/iglu-ruby-client.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
     'wiki_uri'        => 'https://github.com/snowplow/iglu/wiki/Ruby-client'
   }
 
-  s.add_runtime_dependency "httparty", "<= 0.14.0"
+  s.add_runtime_dependency "httparty", "~> 0.15.0"
   s.add_runtime_dependency "json-schema", "~> 2.7.0", '>= 2.7.0'
   s.add_development_dependency "rspec", "~> 2.14", '>= 2.14.1'
 

--- a/iglu-ruby-client.gemspec
+++ b/iglu-ruby-client.gemspec
@@ -33,8 +33,8 @@ Gem::Specification.new do |s|
     'wiki_uri'        => 'https://github.com/snowplow/iglu/wiki/Ruby-client'
   }
 
-  s.add_runtime_dependency "httparty", "<= 0.14.0"
-  s.add_runtime_dependency "json-schema", "~> 2.7.0", '>= 2.7.0'
-  s.add_development_dependency "rspec", "~> 2.14", '>= 2.14.1'
+  s.add_runtime_dependency "httparty", "~> 0.15.0"
+  s.add_runtime_dependency "json-schema", '>= 2.7.0'
+  s.add_development_dependency "rspec", "~> 3.4.0"
 
 end

--- a/lib/iglu-client/core.rb
+++ b/lib/iglu-client/core.rb
@@ -20,15 +20,7 @@ module Iglu
   SCHEMAVER_REGEX = Regexp.new "^([1-9][0-9]*)-(0|[1-9][0-9]*)-(0|[1-9][0-9]*)$"
 
   # Class holding SchemaVer data
-  class SchemaVer
-    attr_accessor :model, :revision, :addition
-
-    # Constructor. To initalize from string - use static parse_schemaver
-    def initialize(model, revision, addition)
-      @model = model
-      @revision = revision
-      @addition = addition
-    end
+  class SchemaVer < Struct.new(:model, :revision, :addition)
 
     # Render as string
     def as_string
@@ -40,24 +32,11 @@ module Iglu
       model, revision, addition = version.scan(SCHEMAVER_REGEX).flatten
       SchemaVer.new model.to_i, revision.to_i, addition.to_i
     end
-
-    def ==(other)
-      other.model == @model && other.revision == @revision && other.addition == @addition
-    end
   end
 
 
   # Class holding Schema metadata
-  class SchemaKey
-    attr_accessor :vendor, :name, :format, :version
-
-    # Constructor. To initalize from string - use static parse_key
-    def initialize(vendor, name, format, version)
-      @vendor = vendor
-      @name = name
-      @format = format
-      @version = version
-    end
+  class SchemaKey < Struct.new(:vendor, :name, :format, :version)
 
     # Render as Iglu URI (with `iglu:`)
     def as_uri
@@ -78,10 +57,6 @@ module Iglu
         schema_ver = SchemaVer.parse_schemaver(version)
         SchemaKey.new vendor, name, format, schema_ver
       end
-    end
-
-    def ==(other)
-      other.vendor == @vendor && other.name == @name && other.format == @format && other.version == @version
     end
   end
 

--- a/lib/iglu-client/core.rb
+++ b/lib/iglu-client/core.rb
@@ -87,10 +87,9 @@ module Iglu
 
 
   # Custom validator, allowing to use self-describing JSON Schemas
-  class SelfDescribingSchema < JSON::Schema::Validator
+  class SelfDescribingSchema < JSON::Schema::Draft4
     def initialize
       super
-      extend_schema_definition("http://json-schema.org/draft-04/schema#")
       @uri = URI.parse("http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#")
     end
 

--- a/spec/iglu-client/resolver_spec.rb
+++ b/spec/iglu-client/resolver_spec.rb
@@ -26,8 +26,8 @@ describe Iglu do
 
   it 'correctly parses a standard resolver configuration' do
     resolver = Iglu::Resolver.parse(@json_config)
-    expect(resolver.registries.length) == 2
-    expect(resolver.registries[1].config.name) == "Iglu Central"
+    expect(resolver.registries.length).to eq(2)
+    expect(resolver.registries[1].config.name).to eq("Iglu Central")
   end
 
   it 'throws an exception on resolver configuration not matching its JSON Schema' do
@@ -59,7 +59,7 @@ describe Iglu do
     config = '{ "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#", "description": "Schema for an Iglu resolver\'s configuration", "self": { "vendor": "com.snowplowanalytics.iglu", "name": "resolver-config", "format": "jsonschema", "version": "1-0-0" }, "type": "object", "properties": { "cacheSize": { "type": "number" }, "repositories": { "type": "array", "items": { "type": "object", "properties": { "name": { "type": "string" }, "priority": { "type": "number" }, "vendorPrefixes": { "type": "array", "items": { "type": "string" } }, "connection": { "type": "object", "oneOf": [ { "properties": { "embedded": { "type": "object", "properties": { "path": { "type": "string" } }, "required": ["path"], "additionalProperties": false } }, "required": ["embedded"], "additionalProperties": false }, { "properties": { "http": { "type": "object", "properties": { "uri": { "type": "string", "format": "uri" } }, "required": ["uri"], "additionalProperties": false } }, "required": ["http"], "additionalProperties": false } ] } }, "required": ["name", "priority", "vendorPrefixes", "connection"], "additionalProperties": false } } }, "required": ["cacheSize", "repositories"], "additionalProperties": false }'
 
     result = JSON.parse(config)
-    expect(schema) == result
+    expect(schema).to eq(result)
 
   end
 end

--- a/spec/iglu-client/resolver_spec.rb
+++ b/spec/iglu-client/resolver_spec.rb
@@ -23,13 +23,13 @@ describe Iglu do
     invalid_config = '{"schema": "iglu:com.snowplowanalytics.iglu/resolver-config/jsonschema/1-0-0", "data": { "cacheSize": null, "repositories": [ { "name": "Iglu Central", "priority": 1, "vendorPrefixes": [ "com.snowplowanalytics" ], "connection": { "http": { "uri": "http://iglucentral.com" } } } ] } }'
     @json_invalid_config = JSON.parse(invalid_config, {:symbolize_names => true})
   }
-  
+
   it 'correctly parses a standard resolver configuration' do
     resolver = Iglu::Resolver.parse(@json_config)
     expect(resolver.registries.length) == 2
     expect(resolver.registries[1].config.name) == "Iglu Central"
   end
-  
+
   it 'throws an exception on resolver configuration not matching its JSON Schema' do
     expect { Iglu::Resolver.parse(@json_invalid_config) }.to raise_error(JSON::Schema::ValidationError)
   end
@@ -41,13 +41,15 @@ describe Iglu do
     key1 = Iglu::SchemaKey.new("com.snowplowanalytics.snowplow.enrichments", "api_request_enrichment_config", "jsonschema", Iglu::SchemaVer.new(1,0,0))
     key2 = Iglu::SchemaKey.new("com.snowplowanalytics.snowplow", "duplicate", "jsonschema", Iglu::SchemaVer.new(1,0,0))
     key3 = Iglu::SchemaKey.new("com.snowplowanalytics.iglu", "resolver-config", "jsonschema", Iglu::SchemaVer.new(1,0,0))
+    key4 = Iglu::SchemaKey.new("com.snowplowanalytics.iglu", "resolver-config", "jsonschema", Iglu::SchemaVer.new(1,0,0))
 
     resolver.lookup_schema(key1)
     resolver.lookup_schema(key2)
     resolver.lookup_schema(key2)
     resolver.lookup_schema(key3)
+    resolver.lookup_schema(key4)
 
-    expect(resolver.cache.size) === 3
+    expect(resolver.cache.size).to eq(3)
   end
 
   it 'can lookup schema in bootstrap resolver' do

--- a/spec/iglu-client/schema_key_spec.rb
+++ b/spec/iglu-client/schema_key_spec.rb
@@ -20,7 +20,7 @@ describe Iglu do
     registry = Iglu::Registries::HttpRegistryRef.new(ref_config, "http://iglucentral.com")
     @resolver = Iglu::Resolver.new([registry])
   }
-  
+
   it 'correctly parses and validate a self-describing JSON' do
     instance = '{"schema": "iglu:com.parrable/decrypted_payload/jsonschema/1-0-0", ' \
                ' "data": {' \
@@ -28,7 +28,7 @@ describe Iglu do
                '   "deviceid": "asdfasdfasdfasdfcwer234fa$#ds±f324jo"' \
                ' }' \
                '}'
-    expect(Iglu::SelfDescribingJson.parse_json(JSON.parse(instance)).valid?(@resolver)) == true
+    expect(Iglu::SelfDescribingJson.parse_json(JSON.parse(instance)).valid?(@resolver)).to eq(true)
   end
 
   it 'correctly parses and invalidate an invalid self-describing JSON' do
@@ -38,15 +38,15 @@ describe Iglu do
                '   "deviceid": "asdfasdfasdfasdfcwer234fa$#ds±f324joa"' \
                ' }' \
                '}'
-    expect(Iglu::SelfDescribingJson.parse_json(JSON.parse(instance)).valid?(@resolver)) == false
+    expect(Iglu::SelfDescribingJson.parse_json(JSON.parse(instance)).valid?(@resolver)).to eq(false)
   end
 
   it 'correctly parses Iglu URI into object' do
-    expect(Iglu::SchemaKey.parse_key("iglu:com.snowplowanalytics.snowplow/event/jsonschema/1-0-1")) == Iglu::SchemaKey.new("com.snowplowanalytics.snowplow", "event", "jsonschema", Iglu::SchemaVer.new(1, 0, 1))
+    expect(Iglu::SchemaKey.parse_key("iglu:com.snowplowanalytics.snowplow/event/jsonschema/1-0-1")).to eq(Iglu::SchemaKey.new("com.snowplowanalytics.snowplow", "event", "jsonschema", Iglu::SchemaVer.new(1, 0, 1)))
   end
 
   it 'correctly parses SchemaVer into object' do
-    expect(Iglu::SchemaVer.parse_schemaver("2-0-3")) == Iglu::SchemaVer.new(2, 0, 3)
+    expect(Iglu::SchemaVer.parse_schemaver("2-0-3")).to eq(Iglu::SchemaVer.new(2, 0, 3))
   end
 
   it 'throws exception on an incorrect SchemaKey (without iglu protocol)' do
@@ -65,7 +65,7 @@ describe Iglu do
                ' }' \
                '}'
     json = JSON::parse(instance)
-    expect(@resolver.validate(json)) == true
+    expect(@resolver.validate(json)).to eq(true)
   end
 
   it 'correctly invalidates self-describing JSON (wrong string length) by returning exception' do


### PR DESCRIPTION
Would be great if we could update those gems:

- httparty
- json-schema (Fix [DEPRECATION NOTICE] The preferred way to extend a Validator is by subclassing, rather than #extend_schema_definition. This method will be removed in version >= 3.)
- rspec