### PR TITLE
Update json-schema

### DIFF
--- a/iglu-ruby-client.gemspec
+++ b/iglu-ruby-client.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   }
 
   s.add_runtime_dependency "httparty", "<= 0.14.0"
-  s.add_runtime_dependency "json-schema", "~> 2.7.0", '>= 2.7.0'
+  s.add_runtime_dependency "json-schema", '~> 2.7'
   s.add_development_dependency "rspec", "~> 2.14", '>= 2.14.1'
 
 end

--- a/lib/iglu-client/core.rb
+++ b/lib/iglu-client/core.rb
@@ -66,10 +66,9 @@ module Iglu
 
 
   # Custom validator, allowing to use self-describing JSON Schemas
-  class SelfDescribingSchema < JSON::Schema::Validator
+  class SelfDescribingSchema < JSON::Schema::Draft4
     def initialize
       super
-      extend_schema_definition("http://json-schema.org/draft-04/schema#")
       @uri = URI.parse("http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#")
     end
 


### PR DESCRIPTION
Fix [DEPRECATION NOTICE] The preferred way to extend a Validator is by subclassing, rather than #extend_schema_definition. This method will be removed in version >= 3.)

`~> 2.7` means that it should be greater than 2.7 but smaller than 3.0