### PR TITLE
Allow 0 based versioning

### DIFF
--- a/lib/iglu-client/core.rb
+++ b/lib/iglu-client/core.rb
@@ -14,10 +14,10 @@ require "json-schema"
 module Iglu
 
   # Regular expression to extract metadata from self-describing JSON
-  URI_REGEX = Regexp.new "^iglu:([a-zA-Z0-9\\-_.]+)\/([a-zA-Z0-9\\-_]+)\/([a-zA-Z0-9\\-_]+)\/([1-9][0-9]*(?:-(?:0|[1-9][0-9]*)){2})$"
+  URI_REGEX = Regexp.new "^iglu:([a-zA-Z0-9\\-_.]+)\/([a-zA-Z0-9\\-_]+)\/([a-zA-Z0-9\\-_]+)\/((0|[1-9][0-9]*)(?:-(?:0|[1-9][0-9]*)){2})$"
 
   # Regular expression to extract all parts of SchemaVer: MODEL, REVISION, ADDITION
-  SCHEMAVER_REGEX = Regexp.new "^([1-9][0-9]*)-(0|[1-9][0-9]*)-(0|[1-9][0-9]*)$"
+  SCHEMAVER_REGEX = Regexp.new "^(0|[1-9][0-9]*)-(0|[1-9][0-9]*)-(0|[1-9][0-9]*)$"
 
   # Class holding SchemaVer data
   class SchemaVer < Struct.new(:model, :revision, :addition)

--- a/spec/iglu-client/schema_key_spec.rb
+++ b/spec/iglu-client/schema_key_spec.rb
@@ -57,10 +57,6 @@ describe Iglu do
     expect { Iglu::SchemaVer.parse_schemaver("10-a-1") }.to raise_error(Iglu::IgluError)
   end
 
-  it 'throws exception on an incorrect SchemaVer (0 based versioning)' do
-    expect { Iglu::SchemaVer.parse_schemaver("0-1-2") }.to raise_error(Iglu::IgluError)
-  end
-
   it 'throws exception on an incorrect SchemaVer (with lower case letters)' do
     expect { Iglu::SchemaVer.parse_schemaver("a-b-c") }.to raise_error(Iglu::IgluError)
   end


### PR DESCRIPTION
That kind of versioning works in the snowplow enrichment process( we have self describing events with "0-0-1" versions), so I assume it should be also supported in ruby ruby-iglu-client?