### PR TITLE
Updates restrictions so recent ruby gems can be used

### DIFF
--- a/iglu-ruby-client.gemspec
+++ b/iglu-ruby-client.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
     'wiki_uri'        => 'https://github.com/snowplow/iglu/wiki/Ruby-client'
   }
 
-  s.add_runtime_dependency "httparty", "~> 0.15.0"
+  s.add_runtime_dependency "httparty", "~> 0.15"
   s.add_runtime_dependency "json-schema", '>= 2.7.0'
   s.add_development_dependency "rspec", "~> 3.4.0"
 

--- a/iglu-ruby-client.gemspec
+++ b/iglu-ruby-client.gemspec
@@ -33,8 +33,8 @@ Gem::Specification.new do |s|
     'wiki_uri'        => 'https://github.com/snowplow/iglu/wiki/Ruby-client'
   }
 
-  s.add_runtime_dependency "httparty", "<= 0.14.0"
-  s.add_runtime_dependency "json-schema", "~> 2.7.0", '>= 2.7.0'
-  s.add_development_dependency "rspec", "~> 2.14", '>= 2.14.1'
+  s.add_runtime_dependency "httparty", "~> 0.15.0"
+  s.add_runtime_dependency "json-schema", '>= 2.7.0'
+  s.add_development_dependency "rspec", "~> 3.4.0"
 
 end

--- a/lib/iglu-client/core.rb
+++ b/lib/iglu-client/core.rb
@@ -66,10 +66,9 @@ module Iglu
 
 
   # Custom validator, allowing to use self-describing JSON Schemas
-  class SelfDescribingSchema < JSON::Schema::Validator
+  class SelfDescribingSchema < JSON::Schema::Draft4
     def initialize
       super
-      extend_schema_definition("http://json-schema.org/draft-04/schema#")
       @uri = URI.parse("http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#")
     end
 


### PR DESCRIPTION
Updates the dependencies to be less restrictive, especially around `json-shema` which has been superseded and causes conflicts with more recent versions of rails.

(I've signed contributor agreement.)